### PR TITLE
deprecated util/net/donwload

### DIFF
--- a/docs/dev_guide/contents/newcomers.rst
+++ b/docs/dev_guide/contents/newcomers.rst
@@ -133,7 +133,7 @@ It may be possible your idea may be outside of the scope of the repository you a
 Setting up a development environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The instructions in this following section are based upon three resources:
+The instructions in this following section are based upon two resources:
 
 * `Astropy Contributing Quickstart <https://docs.astropy.org/en/latest/development/quickstart.html>`__
 * `Astropy Contribution Example <https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html>`__

--- a/sunpy/util/net.py
+++ b/sunpy/util/net.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 
 from sunpy.util import replacement_filename
+from sunpy.util.decorators import deprecated
 
 __all__ = ['parse_header', 'slugify', 'get_content_disposition', 'get_filename',
            'get_system_filename', 'download_file', 'download_fileobj']
@@ -126,7 +127,7 @@ def get_system_filename(sock, url, default="file"):
         name = str(default)
     return name.encode(sys.getfilesystemencoding(), 'ignore')
 
-
+@deprecated(since="6.1")
 def download_fileobj(opn, directory, url='', default="file", overwrite=False):
     """
     Download a file from a url into a directory.
@@ -160,7 +161,7 @@ def download_fileobj(opn, directory, url='', default="file", overwrite=False):
         shutil.copyfileobj(opn, fd)
     return path
 
-
+@deprecated(since="6.1")
 def download_file(url, directory, default="file", overwrite=False):
     """
     Download a file from a url into a directory.


### PR DESCRIPTION
deprecated sunpy.util.net.donwload and download_fileobj since they are not used anymore 
and minor docs changes 
fixes #8098 
